### PR TITLE
Complete jargon comparison rendering

### DIFF
--- a/src/scenes/papers/components/PapersPanel.js
+++ b/src/scenes/papers/components/PapersPanel.js
@@ -15,30 +15,22 @@ export default class PapersPanel extends Component {
         super(props);
         this.state = {
             chosenTab: "search",
-            papers: [],
+            searchTabProperties: {
+                papers: []
+            },
         };
 
         // Necessary binding in order to allow children actions
         this.getChosenTab = this.getChosenTab.bind(this);
-        this.getPapers = this.getPapers.bind(this);
-        this.setPapers = this.setPapers.bind(this);
         this.setJargonTab = this.setJargonTab.bind(this);
         this.setSearchTab = this.setSearchTab.bind(this);
+        this.getSearchTabPapers = this.getSearchTabPapers.bind(this);
+        this.setSearchTabPapers = this.setSearchTabPapers.bind(this);
     }
 
 
     getChosenTab() {
         return this.state.chosenTab;
-    }
-
-
-    getPapers() {
-        return this.state.papers;
-    }
-
-
-    setPapers(papers) {
-        this.setState({papers: papers});
     }
 
 
@@ -52,14 +44,28 @@ export default class PapersPanel extends Component {
     }
 
 
+    getSearchTabPapers() {
+        return this.state.searchTabProperties.papers;
+    }
+
+
+    setSearchTabPapers(papers) {
+        this.setState(prevState => ({
+            ...prevState,
+            searchTabProperties: {papers: papers}
+        }));
+    }
+
+
     renderTabHeader() {
         switch (this.state.chosenTab) {
             case "jargon":
-                return <Jargon setPapers={this.setPapers}/>;
+                // TODO: Change for setJargonTabPapers
+                return <Jargon setJargonPapers={this.setSearchTabPapers}/>;
             case "search":
-                return <Search setPapers={this.setPapers}/>;
+                return <Search setSearchPapers={this.setSearchTabPapers}/>;
             default:
-                return <Search setPapers={this.setPapers}/>;
+                return <Search setSearchPapers={this.setSearchTabPapers}/>;
         }
     }
 
@@ -82,7 +88,7 @@ export default class PapersPanel extends Component {
                     </Grid.Row>
                     <Grid.Row className="panel-body-map">
                         <MapCanvas
-                            getPapers={this.getPapers}
+                            getSearchPapers={this.getSearchTabPapers}
                         />
                     </Grid.Row>
                 </Grid.Column>

--- a/src/scenes/papers/components/PapersPanel.js
+++ b/src/scenes/papers/components/PapersPanel.js
@@ -15,15 +15,24 @@ export default class PapersPanel extends Component {
         super(props);
         this.state = {
             chosenTab: "search",
+            jargonTabProperties: {
+                extras: {},
+                papers: [],
+            },
             searchTabProperties: {
                 papers: []
             },
         };
 
-        // Necessary binding in order to allow children actions
+        // Tab choosing related functions
         this.getChosenTab = this.getChosenTab.bind(this);
         this.setJargonTab = this.setJargonTab.bind(this);
         this.setSearchTab = this.setSearchTab.bind(this);
+
+        // Papers related getters and setters
+        this.getJargonTabExtras = this.getJargonTabExtras.bind(this);
+        this.getJargonTabPapers = this.getJargonTabPapers.bind(this);
+        this.setJargonTabPapers = this.setJargonTabPapers.bind(this);
         this.getSearchTabPapers = this.getSearchTabPapers.bind(this);
         this.setSearchTabPapers = this.setSearchTabPapers.bind(this);
     }
@@ -44,6 +53,24 @@ export default class PapersPanel extends Component {
     }
 
 
+    getJargonTabExtras() {
+        return this.state.jargonTabProperties.extras;
+    }
+
+
+    getJargonTabPapers() {
+        return this.state.jargonTabProperties.papers;
+    }
+
+
+    setJargonTabPapers(papers, extras) {
+        this.setState(prevState => ({
+            ...prevState,
+            jargonTabProperties: {papers: papers, extras: extras}
+        }));
+    }
+
+
     getSearchTabPapers() {
         return this.state.searchTabProperties.papers;
     }
@@ -60,8 +87,7 @@ export default class PapersPanel extends Component {
     renderTabHeader() {
         switch (this.state.chosenTab) {
             case "jargon":
-                // TODO: Change for setJargonTabPapers
-                return <Jargon setJargonPapers={this.setSearchTabPapers}/>;
+                return <Jargon setJargonPapers={this.setJargonTabPapers}/>;
             case "search":
                 return <Search setSearchPapers={this.setSearchTabPapers}/>;
             default:
@@ -88,6 +114,8 @@ export default class PapersPanel extends Component {
                     </Grid.Row>
                     <Grid.Row className="panel-body-map">
                         <MapCanvas
+                            getJargonExtras={this.getJargonTabExtras}
+                            getJargonPapers={this.getJargonTabPapers}
                             getSearchPapers={this.getSearchTabPapers}
                         />
                     </Grid.Row>

--- a/src/scenes/papers/components/headers/Jargon.js
+++ b/src/scenes/papers/components/headers/Jargon.js
@@ -8,6 +8,12 @@ import PaperSearchCtl from "../../controllers/paperscape/PaperSearch";
 import PaperSearchPositionCtl from "../../controllers/paperscape/PaperSearchPosition";
 
 
+export const JargonColors = [
+    {key: "blue", text: "blue", rgb: {r: 0,   g: 0, b: 255}},
+    {key: "red",  text: "red",  rgb: {r: 255, g: 0, b: 0}},
+];
+
+
 export default class Jargon extends Component {
 
 
@@ -102,10 +108,10 @@ export default class Jargon extends Component {
                 <Menu secondary>
                     <Menu.Item className="search-menu-item">
                         <Image avatar>
-                            <Icon circular inverted color="blue" name="comment"/>
+                            <Icon circular inverted color={JargonColors[0].text} name="comment"/>
                         </Image>
                         <b className="search-menu-text">
-                            Jargon:
+                            Jargon A:
                         </b>
                         <Input
                             fluid
@@ -115,10 +121,10 @@ export default class Jargon extends Component {
                     </Menu.Item>
                     <Menu.Item className="search-menu-item">
                         <Image avatar>
-                            <Icon circular inverted color="blue" name="comment"/>
+                            <Icon circular inverted color={JargonColors[1].text} name="comment"/>
                         </Image>
                         <b className="search-menu-text">
-                            Jargon:
+                            Jargon B:
                         </b>
                         <Input
                             fluid

--- a/src/scenes/papers/components/headers/Search.js
+++ b/src/scenes/papers/components/headers/Search.js
@@ -50,7 +50,7 @@ export default class Search extends Component {
         }
 
         let papers = await PaperSearchPositionCtl.fetchPapersPos(ids);
-        this.props.setPapers(papers);
+        this.props.setSearchPapers(papers);
     }
 
 

--- a/src/scenes/papers/components/headers/Search.js
+++ b/src/scenes/papers/components/headers/Search.js
@@ -6,11 +6,12 @@ import PaperSearchPositionCtl from "../../controllers/paperscape/PaperSearchPosi
 import { Button, Dropdown, Icon, Image, Input, Menu, Segment } from "semantic-ui-react";
 
 
-const searchOptions = [
-    {key: 'author',     text: 'Author',     value: 'sau'},
-    {key: 'keyword',    text: 'Keyword',    value: 'skw'},
-    {key: 'title',      text: 'Title',      value: 'sti'},
-    {key: 'new-papers', text: 'New papers', value: 'sca'},
+export const SearchOptions = [
+    {key: "arxiv",      text: "Arxiv ID",   value: "saxm"},
+    {key: "author",     text: "Author",     value: "sau"},
+    {key: "keyword",    text: "Keyword",    value: "skw"},
+    {key: "title",      text: "Title",      value: "sti"},
+    {key: "new-papers", text: "New papers", value: "sca"},
 ];
 
 
@@ -77,8 +78,8 @@ export default class Search extends Component {
                         <Dropdown
                             selection
                             className="search-menu-dropdown"
-                            placeholder='By'
-                            options={searchOptions}
+                            placeholder="By"
+                            options={SearchOptions}
                             onChange={(event, change) => this.updateSearchType(change)}
                         />
                     </Menu.Item>
@@ -86,7 +87,7 @@ export default class Search extends Component {
                     <Menu.Menu position="right">
                         <Menu.Item className="search-start-container">
                             <Button
-                                color='blue'
+                                color="blue"
                                 onClick={this.searchPapers}
                             >
                                 Search

--- a/src/scenes/papers/components/map/Map.js
+++ b/src/scenes/papers/components/map/Map.js
@@ -66,7 +66,7 @@ export default class MapCanvas extends Component {
 
 
     render() {
-        const papersList = this.props.getPapers();
+        const papersList = this.props.getSearchPapers();
 
         return (
             // The "ref" prop is necessary to obtain the created instance

--- a/src/scenes/papers/components/map/Map.js
+++ b/src/scenes/papers/components/map/Map.js
@@ -4,6 +4,7 @@ import React, { Component } from "react";
 import config from "../../../../config";
 import MapLayerControl from "./MapLayerControl";
 import MapSelectPaper  from "./MapSelectPaper";
+import { JargonColors } from "../headers/Jargon";
 import { Circle, Map } from "react-leaflet";
 import { CRS } from "leaflet";
 import "leaflet/dist/leaflet.css";
@@ -17,6 +18,9 @@ export default class MapCanvas extends Component {
 
         // Set up at render() time
         this.map = null;
+
+        // Necessary binding in order to access parent functions
+        this.calcJargonColor = this.calcJargonColor.bind(this);
 
         // Necessary binding in order to pass these functions to children
         this.getMap = this.getMap.bind(this);
@@ -47,6 +51,36 @@ export default class MapCanvas extends Component {
     }
 
 
+    convertRGBColor(color) {
+        return `rgb(${color.r}, ${color.g}, ${color.b})`;
+    }
+
+
+    calcJargonColor(paperId) {
+        let jargonExtras = this.props.getJargonExtras();
+        let paperFreqs   = jargonExtras.freqByPaper[paperId];
+
+        let [freqA, freqB]   = Object.values(paperFreqs);
+        let [colorA, colorB] = JargonColors.map(c => c.rgb);
+
+        if (freqA === 0) {
+            return this.convertRGBColor(colorB);
+        }
+        if (freqB === 0) {
+            return this.convertRGBColor(colorA);
+        }
+
+        let colorARatio = freqB > freqA ? freqA / freqB : (1 - (freqB / freqA));
+        let colorBRatio = freqA > freqB ? freqB / freqA : (1 - (freqA / freqB));
+
+        return this.convertRGBColor({
+            r: (colorARatio * colorA.r) + (colorBRatio * colorB.r),
+            g: (colorARatio * colorA.g) + (colorBRatio * colorB.g),
+            b: (colorARatio * colorA.b) + (colorBRatio * colorB.b),
+        });
+    }
+
+
     worldToView(world_X, world_Y) {
         // Leaflet considers [Y, X] not [X, Y]
         return [
@@ -66,7 +100,8 @@ export default class MapCanvas extends Component {
 
 
     render() {
-        const papersList = this.props.getSearchPapers();
+        const jargonPapers = this.props.getJargonPapers();
+        const searchPapers = this.props.getSearchPapers();
 
         return (
             // The "ref" prop is necessary to obtain the created instance
@@ -95,7 +130,16 @@ export default class MapCanvas extends Component {
                     worldToView={this.worldToView}
                 />
 
-                {papersList.map((paper, index) =>
+                {jargonPapers.map((paper, index) =>
+                    <Circle
+                        key={index}
+                        center={this.worldToView(paper.x, paper.y)}
+                        color={this.calcJargonColor(paper.id)}
+                        radius={this.convertRadius(paper.r)}>
+                    </Circle>
+                )}
+
+                {searchPapers.map((paper, index) =>
                     <Circle
                         key={index}
                         center={this.worldToView(paper.x, paper.y)}

--- a/src/scenes/papers/controllers/paperscape/PaperSearch.js
+++ b/src/scenes/papers/controllers/paperscape/PaperSearch.js
@@ -24,6 +24,9 @@ export default class PaperSearchCtl {
         let params = "?callback=";
 
         switch (searchKey) {
+            case "saxm":
+                params += "&saxm=" + searchValue;
+                break;
             case "sau":
                 params += "&sau=" + searchValue;
                 break;


### PR DESCRIPTION
This PR completes the jargon comparison functionality, by combining the API results of the Paperscape API with our own jargon frequencies API, in addition to the final color gradient rendering.

The relevant changes are within the following files:
- `components/Paperspanel.js`: storing the jargon metrics results.
- `components/map/Map.js`: calculating the color gradient for each paper on the jargon comparison.
- `components/headers/Jargon.js`: combining paperscape and our own API results.
- `controllers/paperscape/PaperSearch.js`: allowing the search by ArXiv ID (using keyword `saxm`).