### PR TITLE
Implement jargon comparison

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,7 +21,7 @@ build: clean
 .PHONY: deploy
 deploy:
 	@echo "Deploying project"
-	@serve -s build
+	@npm start
 
 
 .PHONY: docker-build

--- a/src/config.js
+++ b/src/config.js
@@ -51,6 +51,7 @@ const config = {
     /* Dialect map server */
     dialectMapHost: window.env.SERVER_API_HOST,
     dialectMapPort: window.env.SERVER_API_PORT,
+    dialectMapURL: `${window.env.SERVER_API_HOST}:${window.env.SERVER_API_PORT}`,
 
 
     /* PaperScape URLs */

--- a/src/scenes/papers/components/headers/Jargon.js
+++ b/src/scenes/papers/components/headers/Jargon.js
@@ -2,6 +2,8 @@
 
 import React, { Component } from "react";
 import { Button, Icon, Image, Input, Menu, Segment } from "semantic-ui-react";
+import JargonSearchCtl from "../../controllers/backend/JargonSearch";
+import MetricSearchCtl from "../../controllers/backend/MetricSearch";
 
 
 export default class Jargon extends Component {
@@ -9,7 +11,59 @@ export default class Jargon extends Component {
 
     constructor(props) {
         super(props);
-        this.state = {};
+        this.state = {
+            searchedJargonA: "",
+            searchedJargonB: "",
+        };
+
+        // Necessary binding in order to access parent functions
+        this.searchPapers = this.searchPapers.bind(this);
+    }
+
+
+    updateJargonA(event) {
+        this.setState({
+            searchedJargonA: event.target.value
+        });
+    }
+
+
+    updateJargonB(event) {
+        this.setState({
+            searchedJargonB: event.target.value
+        });
+    }
+
+
+    reduceJargonAbsFrequency(acc, metric) {
+        let id = metric.arxivID
+        acc[id] = (acc[id] || {})
+        acc[id][metric.jargonID] = metric.absFreq;
+        return acc
+    }
+
+
+    async searchPapers() {
+        let jargons  = [this.state.searchedJargonA, this.state.searchedJargonB]
+        let promises = jargons.map(j => this.searchMetrics(j))
+
+        let metrics = (await Promise.all(promises)).flat()
+        let jargonFreq = metrics.reduce(this.reduceJargonAbsFrequency, {})
+        console.log(jargonFreq)
+
+        //console.log(jargonFreq)
+        // Get paper coordinates from paperscape
+        // Draw
+    }
+
+
+    async searchMetrics(jargon) {
+        let jargonID = await JargonSearchCtl.fetchJargonID(jargon);
+        if (jargonID === null) {
+            return [];
+        }
+
+        return await MetricSearchCtl.fetchLatestMetrics(jargonID);
     }
 
 
@@ -28,6 +82,7 @@ export default class Jargon extends Component {
                         <Input
                             fluid
                             placeholder="Free energy..."
+                            onChange={event => this.updateJargonA(event)}
                         />
                     </Menu.Item>
                     <Menu.Item className="search-menu-item">
@@ -40,13 +95,16 @@ export default class Jargon extends Component {
                         <Input
                             fluid
                             placeholder="ELBO..."
+                            onChange={event => this.updateJargonB(event)}
                         />
                     </Menu.Item>
 
                     <Menu.Menu position="right">
                         <Menu.Item className="search-start-container">
                             <Button
-                                color='blue'>
+                                color='blue'
+                                onClick={this.searchPapers}
+                            >
                                 Compare
                             </Button>
                         </Menu.Item>

--- a/src/scenes/papers/components/headers/Search.js
+++ b/src/scenes/papers/components/headers/Search.js
@@ -1,8 +1,8 @@
 /* encoding: utf-8 */
 
 import React, { Component } from "react";
-import PaperSearchCtl from "../../controllers/PaperSearch";
-import PaperSearchPositionCtl from "../../controllers/PaperSearchPosition";
+import PaperSearchCtl from "../../controllers/paperscape/PaperSearch";
+import PaperSearchPositionCtl from "../../controllers/paperscape/PaperSearchPosition";
 import { Button, Dropdown, Icon, Image, Input, Menu, Segment } from "semantic-ui-react";
 
 

--- a/src/scenes/papers/components/map/MapLayerControl.js
+++ b/src/scenes/papers/components/map/MapLayerControl.js
@@ -2,7 +2,7 @@
 
 import React, { Component } from "react";
 import config from "../../../../config";
-import MapLabelsCtl from "../../controllers/MapLabels";
+import MapLabelsCtl from "../../controllers/paperscape/MapLabels";
 import MapTilesLayer from "./MapTilesLayer";
 import { FeatureGroup, LayersControl, Marker } from "react-leaflet";
 import { divIcon } from "leaflet";

--- a/src/scenes/papers/components/map/MapSelectPaper.js
+++ b/src/scenes/papers/components/map/MapSelectPaper.js
@@ -2,8 +2,8 @@
 
 import React, { Component } from "react";
 import config from "../../../../config";
-import PaperInfoCtl from "../../controllers/PaperInfo";
-import PaperPositionCtl from "../../controllers/PaperPosition";
+import PaperInfoCtl from "../../controllers/paperscape/PaperInfo";
+import PaperPositionCtl from "../../controllers/paperscape/PaperPosition";
 import MapInfoBox from "./MapInfoBox";
 import { Circle } from "react-leaflet";
 

--- a/src/scenes/papers/controllers/PaperSearch.js
+++ b/src/scenes/papers/controllers/PaperSearch.js
@@ -7,7 +7,7 @@ const paperSearchRespPrefix = "(";
 const paperSearchRespSuffix = ")\n";
 
 
-export default class PaperSearchCtl  {
+export default class PaperSearchCtl {
 
 
     static fetchPapersIDs(searchKey, searchValue) {

--- a/src/scenes/papers/controllers/backend/JargonSearch.js
+++ b/src/scenes/papers/controllers/backend/JargonSearch.js
@@ -1,0 +1,33 @@
+/* encoding: utf-8 */
+
+import config from "../../../../config"
+
+
+export default class JargonSearchCtl {
+
+
+    static fetchJargonID(searchJargon) {
+        let url = config.dialectMapURL
+            + "/jargon/string/"
+            + encodeURIComponent(searchJargon);
+
+        return fetch(url, {})
+            .then(resp => resp.json())
+            .then(json => this._handleJargonSearchResp(json))
+            .catch(err => console.log(err));
+    }
+
+
+    static _handleJargonSearchResp(json) {
+        let jargonID = null;
+
+        try {
+            jargonID = json["jargon_id"];
+        }
+        catch(error) {
+            console.log(error);
+        }
+
+        return jargonID;
+    }
+}

--- a/src/scenes/papers/controllers/backend/MetricSearch.js
+++ b/src/scenes/papers/controllers/backend/MetricSearch.js
@@ -1,0 +1,34 @@
+/* encoding: utf-8 */
+
+import config from "../../../../config"
+import PaperJargonMetric from "../../models/PaperMetric";
+
+
+export default class MetricSearchCtl {
+
+
+    static fetchLatestMetrics(jargonID) {
+        let url = config.dialectMapURL
+            + "/paper/metrics/latest/"
+            + encodeURIComponent(jargonID);
+
+        return fetch(url, {})
+            .then(resp => resp.json())
+            .then(json => this._handleMetricSearchResp(json))
+            .catch(err => console.log(err));
+    }
+
+
+    static _handleMetricSearchResp(json) {
+        let metrics = [];
+
+        try {
+            metrics = json.map(metric => new PaperJargonMetric(metric));
+        }
+        catch(error) {
+            console.log(error);
+        }
+
+        return metrics;
+    }
+}

--- a/src/scenes/papers/controllers/paperscape/MapLabels.js
+++ b/src/scenes/papers/controllers/paperscape/MapLabels.js
@@ -1,6 +1,6 @@
 /* encoding: utf-8 */
 
-import config from "../../../config"
+import config from "../../../../config"
 
 
 const labelsRespPrefix = "lz_Z_X_Y(";

--- a/src/scenes/papers/controllers/paperscape/PaperInfo.js
+++ b/src/scenes/papers/controllers/paperscape/PaperInfo.js
@@ -1,7 +1,7 @@
 /* encoding: utf-8 */
 
-import config from "../../../config"
-import PaperInfo from "../models/PaperInfo"
+import config from "../../../../config"
+import PaperInfo from "../../models/PaperInfo"
 
 
 const paperInfoRespPrefix = "(";

--- a/src/scenes/papers/controllers/paperscape/PaperPosition.js
+++ b/src/scenes/papers/controllers/paperscape/PaperPosition.js
@@ -1,7 +1,7 @@
 /* encoding: utf-8 */
 
-import config from "../../../config"
-import PaperPosition from "../models/PaperPosition"
+import config from "../../../../config"
+import PaperPosition from "../../models/PaperPosition"
 
 
 const paperPosRespPrefix = "(";

--- a/src/scenes/papers/controllers/paperscape/PaperSearch.js
+++ b/src/scenes/papers/controllers/paperscape/PaperSearch.js
@@ -1,6 +1,6 @@
 /* encoding: utf-8 */
 
-import config from "../../../config"
+import config from "../../../../config"
 
 
 const paperSearchRespPrefix = "(";

--- a/src/scenes/papers/controllers/paperscape/PaperSearchPosition.js
+++ b/src/scenes/papers/controllers/paperscape/PaperSearchPosition.js
@@ -1,7 +1,7 @@
 /* encoding: utf-8 */
 
-import config from "../../../config"
-import PaperPosition from "../models/PaperPosition"
+import config from "../../../../config"
+import PaperPosition from "../../models/PaperPosition"
 
 
 export default class PaperSearchPositionCtl  {

--- a/src/scenes/papers/models/PaperMetric.js
+++ b/src/scenes/papers/models/PaperMetric.js
@@ -1,0 +1,15 @@
+/* encoding: utf-8 */
+
+
+export default class PaperJargonMetric {
+
+
+    constructor(data) {
+        this.id       = data["metric_id"];
+        this.jargonID = data["jargon_id"];
+        this.arxivID  = data["arxiv_id"];
+        this.arxivRev = data["arxiv_rev"];
+        this.absFreq  = data["abs_freq"];
+        this.relFreq  = data["rel_freq"];
+    }
+}


### PR DESCRIPTION
This PR combines the previous branch-to-branch [_Complete Jargon comparisson rendering_ PR](https://github.com/ds3-nyu-archive/ds-dialect-map-ui/pull/11), with the definition of new API controllers and models to completely implement the **jargon comparison functionality**.

New controllers:
- [controllers/backend/JargonSearch.js](https://github.com/ds3-nyu-archive/ds-dialect-map-ui/compare/jargon-search?expand=1#diff-ac0cb2a98af97fe1985d8448497313c85e6f2ffe44319b89b15d8510fd336914).
- [controllers/backend/MetricsSearch.js](https://github.com/ds3-nyu-archive/ds-dialect-map-ui/compare/jargon-search?expand=1#diff-f5a7e89054500bb137f6248ab2b6f7dce85574e0665f80c1457c17119b2f0baa).

New models:
- [PaperJargonMetric](https://github.com/ds3-nyu-archive/ds-dialect-map-ui/compare/jargon-search?expand=1#diff-8d22e4d1a6173e4c8c3a79aa4c633af849e1c8828abe1907c974a4674c785287) (doing a simple mapping between the API provided fields, and the UI useful ones).

---

In addition, all PaperScape API controllers have been moved to a `controllers/paperscape` folder, to better differentiate them from the ones targeting our own API.