### PR TITLE
Define code style formatter

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,35 @@
+name: Continuous Integration
+
+on:
+  push:
+    branches:
+      - master
+  pull_request:
+    branches:
+      - master
+
+jobs:
+
+  check:
+    needs: []
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Set up GitHub Actions"
+        uses: actions/checkout@v2
+      - name: "Setup node"
+        uses: actions/setup-node@v2
+        with:
+          node-version: 15
+      - name: "Install dev dependencies"
+        run: npm install --silent --only=dev
+      - name: "Check code format"
+        run: make check
+
+  build:
+    needs: [check]
+    runs-on: ubuntu-latest
+    steps:
+      - name: "Set up GitHub Actions"
+        uses: actions/checkout@v2
+      - name: "Build Docker image"
+        run: make docker-build

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,0 +1,9 @@
+fail_fast: true
+
+repos:
+  -   repo: https://github.com/pre-commit/mirrors-prettier
+      rev: 2.2.1
+      hooks:
+        - id: prettier
+          name: "JavaScript format checker"
+          args: ["--check", "src/**/*.js"]

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,8 @@
+{
+  "arrowParens": "avoid",
+  "bracketSpacing": true,
+  "insertPragma": false,
+  "printWidth": 90,
+  "tabWidth": 4,
+  "trailingComma": "es5"
+}

--- a/Dockerfile
+++ b/Dockerfile
@@ -6,7 +6,7 @@ WORKDIR /app
 COPY . /app
 
 # Install dependencies and web server
-RUN npm install --silent
+RUN npm install --silent --only=prod
 RUN npm install --global serve
 
 # Build for production

--- a/Makefile
+++ b/Makefile
@@ -6,6 +6,12 @@ GCP_REGISTRY  ?= "us.gcr.io"
 GCP_IMAGE_NAME = $(GCP_REGISTRY)/$(GCP_PROJECT)/$(IMAGE_NAME)
 
 
+.PHONY: check
+check:
+	@echo "Checking code format"
+	@npx prettier --check "src/**/*.js"
+
+
 .PHONY: clean
 clean:
 	@echo "Cleaning built folder"

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ the Data Science and Software Services (DS3) funded projects.
 ## About
 
 This project provides a web client for the [PaperScape project][paperscape-blog],
-taking the [PaperSpace public front-end][paperscape-ui] as inspiration, and using a modern 
+taking the [PaperSpace public front-end][paperscape-ui] as inspiration, and using a modern
 and standardized front-end stack:
 
 - [React][react-webpage] ⚛️
@@ -31,19 +31,19 @@ npm install
 npm install --global serve
 ```
 
+
 ### Project development
-```shell script
-npm start
-```
-
-### Project build
-```shell script
-make build
-```
-
-### Project deploy
+To start a development server:
 ```shell script
 make deploy
+```
+
+
+### Formatting
+All JavaScript files are formatted using [Prettier][prettier-web], and the custom properties defined
+in the `.prettierrc.json` file. To check for code style inconsistencies:
+```shell script
+make check
 ```
 
 
@@ -97,6 +97,7 @@ and specially Rob J. Knegjens for being in contact with us during the developmen
 [gcloud-cli-setup]: https://cloud.google.com/sdk/docs/install
 [paperscape-blog]: https://blog.paperscape.org/
 [paperscape-ui]: https://github.com/paperscape/paperscape-mapclient
+[prettier-web]: https://prettier.io/docs/en/index.html
 [react-env-docs]: https://create-react-app.dev/docs/adding-custom-environment-variables/
 [react-webpage]: https://reactjs.org/
 [semantic-webpage]: https://react.semantic-ui.com/

--- a/package.json
+++ b/package.json
@@ -12,6 +12,9 @@
     "semantic-ui-css": "^2.4.1",
     "semantic-ui-react": "^0.88.2"
   },
+  "devDependencies": {
+    "prettier": "2.2.1"
+  },
   "scripts": {
     "prestart": "./scripts/parse-env.sh --destination public",
     "start": "react-scripts start",

--- a/src/config.js
+++ b/src/config.js
@@ -1,6 +1,5 @@
 /* encoding: utf-8 */
 
-
 /* IMPORTANT NOTE:
  *
  * Previously, a CORS-proxy was necessary to parse PaperScape responses
@@ -11,18 +10,18 @@
  * Redirect: https://cors-anywhere.herokuapp.com/
  */
 
-
 const config = {
-
     /* Leaflet map properties */
-    mapBoundsCoords: [[-2000, 0], [0, 2000]],
+    mapBoundsCoords: [
+        [-2000, 0],
+        [0, 2000],
+    ],
     mapBoundsViscosity: 0.8,
     mapInitialCenter: [-1000, 1000],
     mapInitialZoom: 0,
     mapZoomControl: false,
     mapZoomDelta: 0.25,
     mapZoomSnap: 0.25,
-
 
     /* PaperScape map properties
      *
@@ -39,13 +38,13 @@ const config = {
     worldToViewScale: null,
 
     worldLabels: {
-        0: {"nx": 1, "ny": 1},
-        1: {"nx": 1, "ny": 1},
-        2: {"nx": 1, "ny": 1},
-        3: {"nx": 1, "ny": 1},
-        4: {"nx": 2, "ny": 2},
-        5: {"nx": 4, "ny": 4},
-        6: {"nx": 8, "ny": 8},
+        0: { nx: 1, ny: 1 },
+        1: { nx: 1, ny: 1 },
+        2: { nx: 1, ny: 1 },
+        3: { nx: 1, ny: 1 },
+        4: { nx: 2, ny: 2 },
+        5: { nx: 4, ny: 4 },
+        6: { nx: 8, ny: 8 },
     },
 
     /* Dialect map server */
@@ -53,18 +52,15 @@ const config = {
     dialectMapPort: window.env.SERVER_API_PORT,
     dialectMapURL: `${window.env.SERVER_API_HOST}:${window.env.SERVER_API_PORT}`,
 
-
     /* PaperScape URLs */
     papersDataURL: "https://paperscape.org/wombat",
     worldConfigURL: "https://tile1.paperscape.org/world/world_index.json",
     labelsJsonHost: "https://tile1.paperscape.org/world/zones",
 
-
     /* PaperScape tiles URLs */
     tilesColorHost: "https://tile{s}.paperscape.org/world/tiles/{z}/{x}/{y}.png",
-    tilesGreyHost:  "https://tile{s}.paperscape.org/world/tiles-hm/{z}/{x}/{y}.png",
-    tilesAttrib:    "<a href=https://github.com/paperscape>PaperScape</a>",
+    tilesGreyHost: "https://tile{s}.paperscape.org/world/tiles-hm/{z}/{x}/{y}.png",
+    tilesAttrib: "<a href=https://github.com/paperscape>PaperScape</a>",
 };
-
 
 export default config;

--- a/src/controllers/ConfigLoader.js
+++ b/src/controllers/ConfigLoader.js
@@ -2,37 +2,30 @@
 
 import config from "../config";
 
-
 const configRespPrefix = "world_index(";
 const configRespSuffix = ")";
 
-
 export default class ConfigLoader {
     /** Class to load the initial map configuration from Paperscape */
-
 
     static _calcWorldToViewScale(tilePixels, tilePixelsAtZ0) {
         return tilePixels / tilePixelsAtZ0;
     }
 
-
     static _calcViewToWorldScale(tilePixels, tilePixelsAtZ0) {
         return tilePixelsAtZ0 / tilePixels;
     }
-
 
     static _handlePaperIDResp(text) {
         let body = this._pruneWorldConfigResp(text);
         return JSON.parse(body);
     }
 
-
     static _pruneWorldConfigResp(body) {
-        let startStr  = configRespPrefix.length;
+        let startStr = configRespPrefix.length;
         let finishStr = body.length - configRespSuffix.length;
         return body.substring(startStr, finishStr);
     }
-
 
     static _updateConfig(conf) {
         config.worldMinX = conf["xmin"];
@@ -47,10 +40,15 @@ export default class ConfigLoader {
          * Between tile pixels and world pixels at zoom 0.
          * As it is not the case, scaling need to be performed
          */
-        config.viewToWorldScale = this._calcViewToWorldScale(conf["pixelw"], conf["tilings"][0]["tw"]);
-        config.worldToViewScale = this._calcWorldToViewScale(conf["pixelw"], conf["tilings"][0]["tw"]);
+        config.viewToWorldScale = this._calcViewToWorldScale(
+            conf["pixelw"],
+            conf["tilings"][0]["tw"]
+        );
+        config.worldToViewScale = this._calcWorldToViewScale(
+            conf["pixelw"],
+            conf["tilings"][0]["tw"]
+        );
     }
-
 
     static async loadPaperscapeConfig() {
         console.log("Loading PaperScape configuration...");
@@ -60,6 +58,6 @@ export default class ConfigLoader {
             .then(text => this._handlePaperIDResp(text));
 
         this._updateConfig(conf);
-        console.log("PaperScape configuration loaded")
+        console.log("PaperScape configuration loaded");
     }
 }

--- a/src/controllers/ConfigLoader.js
+++ b/src/controllers/ConfigLoader.js
@@ -8,6 +8,7 @@ const configRespSuffix = ")";
 
 
 export default class ConfigLoader {
+    /** Class to load the initial map configuration from Paperscape */
 
 
     static _calcWorldToViewScale(tilePixels, tilePixelsAtZ0) {

--- a/src/index.js
+++ b/src/index.js
@@ -1,25 +1,23 @@
 /* encoding: utf-8 */
 
-import React from 'react';
-import ReactDOM from 'react-dom';
-import * as serviceWorker from './serviceWorker';
-import { BrowserRouter, Route } from 'react-router-dom';
+import React from "react";
+import ReactDOM from "react-dom";
+import * as serviceWorker from "./serviceWorker";
+import { BrowserRouter, Route } from "react-router-dom";
 import ConfigLoader from "./controllers/ConfigLoader";
-import PapersMap from './scenes/papers/Papers';
+import PapersMap from "./scenes/papers/Papers";
 import "semantic-ui-css/semantic.min.css";
-import './index.css';
-
+import "./index.css";
 
 ConfigLoader.loadPaperscapeConfig().then(render);
-
 
 function render() {
     ReactDOM.render(
         <BrowserRouter>
-            <Route exact path="/" component={PapersMap}/>
-            <Route exact path="/map" component={PapersMap}/>
+            <Route exact path="/" component={PapersMap} />
+            <Route exact path="/map" component={PapersMap} />
         </BrowserRouter>,
-        document.getElementById('root')
+        document.getElementById("root")
     );
 
     // If you want your app to work offline and load faster, you can change

--- a/src/scenes/papers/Papers.js
+++ b/src/scenes/papers/Papers.js
@@ -8,6 +8,7 @@ import "./Papers.css";
 
 
 export default class PapersMap extends Component {
+    /** Component containing the whole papers map scene */
 
 
     render() {

--- a/src/scenes/papers/Papers.js
+++ b/src/scenes/papers/Papers.js
@@ -6,27 +6,23 @@ import PapersHeader from "./components/Header";
 import PapersPanel from "./components/PapersPanel";
 import "./Papers.css";
 
-
 export default class PapersMap extends Component {
     /** Component containing the whole papers map scene */
-
 
     render() {
         return (
             <Grid className="papers-layout">
-
                 <Grid.Row stretched className="papers-header">
                     <Grid.Column width={16}>
-                        <PapersHeader/>
+                        <PapersHeader />
                     </Grid.Column>
                 </Grid.Row>
 
                 <Grid.Row stretched className="papers-body">
                     <Grid.Column width={16}>
-                        <PapersPanel/>
+                        <PapersPanel />
                     </Grid.Column>
                 </Grid.Row>
-
             </Grid>
         );
     }

--- a/src/scenes/papers/components/Header.js
+++ b/src/scenes/papers/components/Header.js
@@ -6,6 +6,7 @@ import HeaderModal from "./HeaderModal";
 
 
 export default class PapersHeader extends Component {
+    /** Component defining the global scene header */
 
 
     render() {

--- a/src/scenes/papers/components/Header.js
+++ b/src/scenes/papers/components/Header.js
@@ -4,10 +4,8 @@ import React, { Component } from "react";
 import { Header, Menu, Segment } from "semantic-ui-react";
 import HeaderModal from "./HeaderModal";
 
-
 export default class PapersHeader extends Component {
     /** Component defining the global scene header */
-
 
     render() {
         return (
@@ -18,7 +16,7 @@ export default class PapersHeader extends Component {
                     </Menu.Item>
 
                     <Menu.Menu position="right">
-                        <HeaderModal/>
+                        <HeaderModal />
                     </Menu.Menu>
                 </Menu>
             </Segment>

--- a/src/scenes/papers/components/HeaderModal.js
+++ b/src/scenes/papers/components/HeaderModal.js
@@ -4,42 +4,51 @@ import React, { Component } from "react";
 import { Header, Image, Modal, Segment } from "semantic-ui-react";
 import Logo from "../../../images/DS3_logo.png";
 
-
 export default class PapersModal extends Component {
     /** Component defining the center overlaid box upon information request */
 
-
     render() {
         return (
-            <Modal trigger={
-                <Segment basic className="papers-header-info">Info</Segment>
-            }>
-                <Modal.Header>
-                    Map of Jargon Across Domains
-                </Modal.Header>
+            <Modal
+                trigger={
+                    <Segment basic className="papers-header-info">
+                        Info
+                    </Segment>
+                }
+            >
+                <Modal.Header>Map of Jargon Across Domains</Modal.Header>
 
                 <Modal.Content image>
                     <Image wrapped size="medium" src={Logo} />
                     <Modal.Description>
-                        <Header>
-                            Project description
-                        </Header>
+                        <Header>Project description</Header>
                         <p>
-                            <i>Map of Jargon Across Domains</i> is a project
-                            by the NYU Data Science and Software Services initiative
-                            <a href="https://cds.nyu.edu/ds3/" rel="noopener noreferrer" target="_blank"> (DS3)</a>,
-                            that compares jargon areas of influence by using
-                            the visual representation of ArXiv stored papers
-                            provided by the PaperScape project.
+                            <i>Map of Jargon Across Domains</i> is a project by the NYU
+                            Data Science and Software Services initiative
+                            <a
+                                href="https://cds.nyu.edu/ds3/"
+                                rel="noopener noreferrer"
+                                target="_blank"
+                            >
+                                {" (DS3)"}
+                            </a>
+                            , that compares jargon areas of influence by using the visual
+                            representation of ArXiv stored papers provided by the
+                            PaperScape project.
                         </p>
                         <p>
                             This web client has been created with the help of
-                            <a href="https://robjk.net/" rel="noopener noreferrer" target="_blank"> Rob J. Knegjens</a>,
-                            one of the original PaperScape authors.
+                            <a
+                                href="https://robjk.net/"
+                                rel="noopener noreferrer"
+                                target="_blank"
+                            >
+                                {" Rob J. Knegjens"}
+                            </a>
+                            , one of the original PaperScape authors.
                         </p>
                     </Modal.Description>
                 </Modal.Content>
-
             </Modal>
         );
     }

--- a/src/scenes/papers/components/HeaderModal.js
+++ b/src/scenes/papers/components/HeaderModal.js
@@ -6,6 +6,7 @@ import Logo from "../../../images/DS3_logo.png";
 
 
 export default class PapersModal extends Component {
+    /** Component defining the center overlaid box upon information request */
 
 
     render() {

--- a/src/scenes/papers/components/PapersPanel.js
+++ b/src/scenes/papers/components/PapersPanel.js
@@ -7,10 +7,8 @@ import MapCanvas from "./map/Map";
 import Jargon from "./headers/Jargon";
 import Search from "./headers/Search";
 
-
 export default class PapersPanel extends Component {
     /** Component defining the main section div (sidebar + header + map) */
-
 
     constructor(props) {
         super(props);
@@ -21,7 +19,7 @@ export default class PapersPanel extends Component {
                 papers: [],
             },
             searchTabProperties: {
-                papers: []
+                papers: [],
             },
         };
 
@@ -38,69 +36,58 @@ export default class PapersPanel extends Component {
         this.setSearchTabPapers = this.setSearchTabPapers.bind(this);
     }
 
-
     getChosenTab() {
         return this.state.chosenTab;
     }
 
-
     setJargonTab() {
-        this.setState({chosenTab: "jargon"});
+        this.setState({ chosenTab: "jargon" });
     }
-
 
     setSearchTab() {
-        this.setState({chosenTab: "search"});
+        this.setState({ chosenTab: "search" });
     }
-
 
     getJargonTabExtras() {
         return this.state.jargonTabProperties.extras;
     }
 
-
     getJargonTabPapers() {
         return this.state.jargonTabProperties.papers;
     }
 
-
     setJargonTabPapers(papers, extras) {
         this.setState(prevState => ({
             ...prevState,
-            jargonTabProperties: {papers: papers, extras: extras}
+            jargonTabProperties: { papers: papers, extras: extras },
         }));
     }
-
 
     getSearchTabPapers() {
         return this.state.searchTabProperties.papers;
     }
 
-
     setSearchTabPapers(papers) {
         this.setState(prevState => ({
             ...prevState,
-            searchTabProperties: {papers: papers}
+            searchTabProperties: { papers: papers },
         }));
     }
-
 
     renderTabHeader() {
         switch (this.state.chosenTab) {
             case "jargon":
-                return <Jargon setJargonPapers={this.setJargonTabPapers}/>;
+                return <Jargon setJargonPapers={this.setJargonTabPapers} />;
             case "search":
-                return <Search setSearchPapers={this.setSearchTabPapers}/>;
+                return <Search setSearchPapers={this.setSearchTabPapers} />;
             default:
-                return <Search setSearchPapers={this.setSearchTabPapers}/>;
+                return <Search setSearchPapers={this.setSearchTabPapers} />;
         }
     }
-
 
     render() {
         return (
             <Grid stretched>
-
                 <Grid.Column width={1} className="panel-body-sidebar">
                     <PapersSidebar
                         getChosenTab={this.getChosenTab}
@@ -111,7 +98,7 @@ export default class PapersPanel extends Component {
 
                 <Grid.Column width={15} className="panel-body-main">
                     <Grid.Row className="panel-body-header">
-                        { this.renderTabHeader() }
+                        {this.renderTabHeader()}
                     </Grid.Row>
                     <Grid.Row className="panel-body-map">
                         <MapCanvas
@@ -121,7 +108,6 @@ export default class PapersPanel extends Component {
                         />
                     </Grid.Row>
                 </Grid.Column>
-
             </Grid>
         );
     }

--- a/src/scenes/papers/components/PapersPanel.js
+++ b/src/scenes/papers/components/PapersPanel.js
@@ -9,6 +9,7 @@ import Search from "./headers/Search";
 
 
 export default class PapersPanel extends Component {
+    /** Component defining the main section div (sidebar + header + map) */
 
 
     constructor(props) {

--- a/src/scenes/papers/components/PapersSidebar.js
+++ b/src/scenes/papers/components/PapersSidebar.js
@@ -5,6 +5,7 @@ import { Icon, Menu } from "semantic-ui-react";
 
 
 export default class PapersSidebar extends Component {
+    /** Component defining the main section sidebar to change between tabs */
 
 
     isSearchActive() {

--- a/src/scenes/papers/components/PapersSidebar.js
+++ b/src/scenes/papers/components/PapersSidebar.js
@@ -3,10 +3,8 @@
 import React, { Component } from "react";
 import { Icon, Menu } from "semantic-ui-react";
 
-
 export default class PapersSidebar extends Component {
     /** Component defining the main section sidebar to change between tabs */
-
 
     isSearchActive() {
         return this.props.getChosenTab() === "search";
@@ -16,9 +14,7 @@ export default class PapersSidebar extends Component {
         return this.props.getChosenTab() === "jargon";
     }
 
-
     render() {
-
         // Change-state functions passed by the parent
         const { setJargonTab, setSearchTab } = this.props;
 
@@ -29,14 +25,14 @@ export default class PapersSidebar extends Component {
                     active={this.isSearchActive()}
                     onClick={setSearchTab}
                 >
-                    <Icon circular inverted color="blue" name="search"/>
+                    <Icon circular inverted color="blue" name="search" />
                 </Menu.Item>
                 <Menu.Item
                     name="jargon"
                     active={this.isJargonActive()}
                     onClick={setJargonTab}
                 >
-                    <Icon circular inverted color="blue" name="comment"/>
+                    <Icon circular inverted color="blue" name="comment" />
                 </Menu.Item>
             </Menu>
         );

--- a/src/scenes/papers/components/headers/Jargon.js
+++ b/src/scenes/papers/components/headers/Jargon.js
@@ -16,6 +16,7 @@ export const JargonColors = [
 
 
 export default class Jargon extends Component {
+    /** Component to define the jargon terms comparison across papers */
 
 
     constructor(props) {

--- a/src/scenes/papers/components/headers/Jargon.js
+++ b/src/scenes/papers/components/headers/Jargon.js
@@ -8,6 +8,7 @@ import PaperSearchCtl from "../../controllers/paperscape/PaperSearch";
 import PaperSearchPositionCtl from "../../controllers/paperscape/PaperSearchPosition";
 
 
+// prettier-ignore
 export const JargonColors = [
     {key: "blue", text: "blue", rgb: {r: 0,   g: 0, b: 255}},
     {key: "red",  text: "red",  rgb: {r: 255, g: 0, b: 0}},

--- a/src/scenes/papers/components/headers/Jargon.js
+++ b/src/scenes/papers/components/headers/Jargon.js
@@ -7,17 +7,14 @@ import MetricSearchCtl from "../../controllers/backend/MetricSearch";
 import PaperSearchCtl from "../../controllers/paperscape/PaperSearch";
 import PaperSearchPositionCtl from "../../controllers/paperscape/PaperSearchPosition";
 
-
 // prettier-ignore
 export const JargonColors = [
     {key: "blue", text: "blue", rgb: {r: 0,   g: 0, b: 255}},
     {key: "red",  text: "red",  rgb: {r: 255, g: 0, b: 0}},
 ];
 
-
 export default class Jargon extends Component {
     /** Component to define the jargon terms comparison across papers */
-
 
     constructor(props) {
         super(props);
@@ -30,63 +27,58 @@ export default class Jargon extends Component {
         this.searchPapersAndExtras = this.searchPapersAndExtras.bind(this);
     }
 
-
     updateJargonA(event) {
         this.setState({
-            searchedJargonA: event.target.value
+            searchedJargonA: event.target.value,
         });
     }
-
 
     updateJargonB(event) {
         this.setState({
-            searchedJargonB: event.target.value
+            searchedJargonB: event.target.value,
         });
     }
 
-
     async queryJargonIds(jargons) {
         let promises = jargons.map(j => JargonSearchCtl.fetchJargonID(j));
-        let results  = await Promise.all(promises);
+        let results = await Promise.all(promises);
 
         return results.filter(id => id !== null);
     }
 
-
     async queryMetrics(jargonIds) {
         let promises = jargonIds.map(id => MetricSearchCtl.fetchLatestMetrics(id));
-        let results  = await Promise.all(promises);
+        let results = await Promise.all(promises);
 
         return results.flat();
     }
-
 
     async queryPaperIds(arxivIds) {
         let promises = arxivIds.map(id => PaperSearchCtl.fetchPapersIDs("saxm", id));
-        let results  = await Promise.all(promises);
+        let results = await Promise.all(promises);
 
         return results.flat();
     }
 
-
     async searchFrequenciesByPaper() {
-        let jargons   = [this.state.searchedJargonA, this.state.searchedJargonB];
+        let jargons = [this.state.searchedJargonA, this.state.searchedJargonB];
         let jargonIds = await this.queryJargonIds(jargons);
-        let metrics   = await this.queryMetrics(jargonIds);
+        let metrics = await this.queryMetrics(jargonIds);
 
         let emptyFreqs = {};
-        jargonIds.forEach(id => emptyFreqs[id] = 0);
+        jargonIds.forEach(id => (emptyFreqs[id] = 0));
 
         let papersFreqs = {};
-        metrics.forEach(metric => papersFreqs[metric.arxivID] = {...emptyFreqs});
-        metrics.forEach(metric => papersFreqs[metric.arxivID][metric.jargonID] = metric.absFreq);
+        metrics.forEach(metric => (papersFreqs[metric.arxivID] = { ...emptyFreqs }));
+        metrics.forEach(
+            metric => (papersFreqs[metric.arxivID][metric.jargonID] = metric.absFreq)
+        );
 
         return papersFreqs;
     }
 
-
     async searchPapers(arxivIds) {
-        let paperIds = await this.queryPaperIds(arxivIds)
+        let paperIds = await this.queryPaperIds(arxivIds);
         if (paperIds.length === 0) {
             return [];
         }
@@ -94,27 +86,27 @@ export default class Jargon extends Component {
         return await PaperSearchPositionCtl.fetchPapersPos(paperIds);
     }
 
-
     async searchPapersAndExtras() {
-        let freqs  = await this.searchFrequenciesByPaper();
+        let freqs = await this.searchFrequenciesByPaper();
         let axvIds = Object.keys(freqs);
         let papers = await this.searchPapers(axvIds);
-        this.props.setJargonPapers(papers, {freqByPaper: freqs});
+        this.props.setJargonPapers(papers, { freqByPaper: freqs });
     }
 
-
     render() {
-
         return (
             <Segment className="search-container">
                 <Menu secondary>
                     <Menu.Item className="search-menu-item">
                         <Image avatar>
-                            <Icon circular inverted color={JargonColors[0].text} name="comment"/>
+                            <Icon
+                                circular
+                                inverted
+                                color={JargonColors[0].text}
+                                name="comment"
+                            />
                         </Image>
-                        <b className="search-menu-text">
-                            Jargon A:
-                        </b>
+                        <b className="search-menu-text">Jargon A:</b>
                         <Input
                             fluid
                             placeholder="Free energy..."
@@ -123,11 +115,14 @@ export default class Jargon extends Component {
                     </Menu.Item>
                     <Menu.Item className="search-menu-item">
                         <Image avatar>
-                            <Icon circular inverted color={JargonColors[1].text} name="comment"/>
+                            <Icon
+                                circular
+                                inverted
+                                color={JargonColors[1].text}
+                                name="comment"
+                            />
                         </Image>
-                        <b className="search-menu-text">
-                            Jargon B:
-                        </b>
+                        <b className="search-menu-text">Jargon B:</b>
                         <Input
                             fluid
                             placeholder="ELBO..."
@@ -137,10 +132,7 @@ export default class Jargon extends Component {
 
                     <Menu.Menu position="right">
                         <Menu.Item className="search-start-container">
-                            <Button
-                                color='blue'
-                                onClick={this.searchPapersAndExtras}
-                            >
+                            <Button color="blue" onClick={this.searchPapersAndExtras}>
                                 Compare
                             </Button>
                         </Menu.Item>

--- a/src/scenes/papers/components/headers/Search.js
+++ b/src/scenes/papers/components/headers/Search.js
@@ -17,6 +17,7 @@ export const SearchOptions = [
 
 
 export default class Search extends Component {
+    /** Component to define the search query to the PaperScape API */
 
 
     constructor(props) {

--- a/src/scenes/papers/components/headers/Search.js
+++ b/src/scenes/papers/components/headers/Search.js
@@ -6,6 +6,7 @@ import PaperSearchPositionCtl from "../../controllers/paperscape/PaperSearchPosi
 import { Button, Dropdown, Icon, Image, Input, Menu, Segment } from "semantic-ui-react";
 
 
+// prettier-ignore
 export const SearchOptions = [
     {key: "arxiv",      text: "Arxiv ID",   value: "saxm"},
     {key: "author",     text: "Author",     value: "sau"},

--- a/src/scenes/papers/components/headers/Search.js
+++ b/src/scenes/papers/components/headers/Search.js
@@ -5,7 +5,6 @@ import PaperSearchCtl from "../../controllers/paperscape/PaperSearch";
 import PaperSearchPositionCtl from "../../controllers/paperscape/PaperSearchPosition";
 import { Button, Dropdown, Icon, Image, Input, Menu, Segment } from "semantic-ui-react";
 
-
 // prettier-ignore
 export const SearchOptions = [
     {key: "arxiv",      text: "Arxiv ID",   value: "saxm"},
@@ -15,10 +14,8 @@ export const SearchOptions = [
     {key: "new-papers", text: "New papers", value: "sca"},
 ];
 
-
 export default class Search extends Component {
     /** Component to define the search query to the PaperScape API */
-
 
     constructor(props) {
         super(props);
@@ -31,23 +28,23 @@ export default class Search extends Component {
         this.searchPapers = this.searchPapers.bind(this);
     }
 
-
     updateSearch(event) {
         this.setState({
-            paperSearch: event.target.value
+            paperSearch: event.target.value,
         });
     }
-
 
     updateSearchType(change) {
         this.setState({
-            paperSearchType: change.value
+            paperSearchType: change.value,
         });
     }
 
-
     async searchPapers() {
-        let ids = await PaperSearchCtl.fetchPapersIDs(this.state.paperSearchType, this.state.paperSearch);
+        let ids = await PaperSearchCtl.fetchPapersIDs(
+            this.state.paperSearchType,
+            this.state.paperSearch
+        );
         if (ids.length === 0) {
             return;
         }
@@ -56,19 +53,15 @@ export default class Search extends Component {
         this.props.setSearchPapers(papers);
     }
 
-
     render() {
-
         return (
             <Segment className="search-container">
                 <Menu secondary>
                     <Menu.Item className="search-menu-item">
                         <Image avatar>
-                            <Icon circular inverted color="blue" name="filter"/>
+                            <Icon circular inverted color="blue" name="filter" />
                         </Image>
-                        <b className="search-menu-text">
-                            Search:
-                        </b>
+                        <b className="search-menu-text">Search:</b>
                         <Input
                             fluid
                             placeholder="Free energy..."
@@ -88,10 +81,7 @@ export default class Search extends Component {
 
                     <Menu.Menu position="right">
                         <Menu.Item className="search-start-container">
-                            <Button
-                                color="blue"
-                                onClick={this.searchPapers}
-                            >
+                            <Button color="blue" onClick={this.searchPapers}>
                                 Search
                             </Button>
                         </Menu.Item>

--- a/src/scenes/papers/components/map/Map.js
+++ b/src/scenes/papers/components/map/Map.js
@@ -11,6 +11,7 @@ import "leaflet/dist/leaflet.css";
 
 
 export default class MapCanvas extends Component {
+    /** Component containing all the map related information / rendering */
 
 
     constructor(props) {

--- a/src/scenes/papers/components/map/Map.js
+++ b/src/scenes/papers/components/map/Map.js
@@ -136,8 +136,8 @@ export default class MapCanvas extends Component {
                         key={index}
                         center={this.worldToView(paper.x, paper.y)}
                         color={this.calcJargonColor(paper.id)}
-                        radius={this.convertRadius(paper.r)}>
-                    </Circle>
+                        radius={this.convertRadius(paper.r)}
+                    />
                 )}
 
                 {searchPapers.map((paper, index) =>
@@ -145,8 +145,8 @@ export default class MapCanvas extends Component {
                         key={index}
                         center={this.worldToView(paper.x, paper.y)}
                         color={"white"}
-                        radius={this.convertRadius(paper.r)}>
-                    </Circle>
+                        radius={this.convertRadius(paper.r)}
+                    />
                 )}
             </Map>
         );

--- a/src/scenes/papers/components/map/Map.js
+++ b/src/scenes/papers/components/map/Map.js
@@ -2,17 +2,15 @@
 
 import React, { Component } from "react";
 import config from "../../../../config";
-import MapLayerControl from "./MapLayerControl";
-import MapSelectPaper  from "./MapSelectPaper";
 import { JargonColors } from "../headers/Jargon";
+import MapLayerControl from "./MapLayerControl";
+import MapSelectPaper from "./MapSelectPaper";
 import { Circle, Map } from "react-leaflet";
 import { CRS } from "leaflet";
 import "leaflet/dist/leaflet.css";
 
-
 export default class MapCanvas extends Component {
     /** Component containing all the map related information / rendering */
-
 
     constructor(props) {
         super(props);
@@ -29,16 +27,13 @@ export default class MapCanvas extends Component {
         this.worldToView = this.worldToView.bind(this);
     }
 
-
-    componentDidMount () {
+    componentDidMount() {
         setTimeout(() => this.map.invalidateSize(), 200);
     }
-
 
     getMap() {
         return this.map;
     }
-
 
     setMap(ref) {
         if (this.map === null) {
@@ -46,22 +41,19 @@ export default class MapCanvas extends Component {
         }
     }
 
-
     convertRadius(radius) {
         return radius * config.worldToViewScale;
     }
-
 
     convertRGBColor(color) {
         return `rgb(${color.r}, ${color.g}, ${color.b})`;
     }
 
-
     calcJargonColor(paperId) {
         let jargonExtras = this.props.getJargonExtras();
-        let paperFreqs   = jargonExtras.freqByPaper[paperId];
+        let paperFreqs = jargonExtras.freqByPaper[paperId];
 
-        let [freqA, freqB]   = Object.values(paperFreqs);
+        let [freqA, freqB] = Object.values(paperFreqs);
         let [colorA, colorB] = JargonColors.map(c => c.rgb);
 
         if (freqA === 0) {
@@ -71,34 +63,31 @@ export default class MapCanvas extends Component {
             return this.convertRGBColor(colorA);
         }
 
-        let colorARatio = freqB > freqA ? freqA / freqB : (1 - (freqB / freqA));
-        let colorBRatio = freqA > freqB ? freqB / freqA : (1 - (freqA / freqB));
+        let colorARatio = freqB > freqA ? freqA / freqB : 1 - freqB / freqA;
+        let colorBRatio = freqA > freqB ? freqB / freqA : 1 - freqA / freqB;
 
         return this.convertRGBColor({
-            r: (colorARatio * colorA.r) + (colorBRatio * colorB.r),
-            g: (colorARatio * colorA.g) + (colorBRatio * colorB.g),
-            b: (colorARatio * colorA.b) + (colorBRatio * colorB.b),
+            r: colorARatio * colorA.r + colorBRatio * colorB.r,
+            g: colorARatio * colorA.g + colorBRatio * colorB.g,
+            b: colorARatio * colorA.b + colorBRatio * colorB.b,
         });
     }
-
 
     worldToView(world_X, world_Y) {
         // Leaflet considers [Y, X] not [X, Y]
         return [
-            (-1 * (world_Y - config.worldMinY) * config.worldToViewScale),
-            (+1 * (world_X - config.worldMinX) * config.worldToViewScale),
+            -1 * (world_Y - config.worldMinY) * config.worldToViewScale,
+            +1 * (world_X - config.worldMinX) * config.worldToViewScale,
         ];
     }
-
 
     viewToWorld(view_X, view_Y) {
         // PaperScape considers [X, Y] not [Y, X]
         return [
-            (+1 * view_X * config.viewToWorldScale) + config.worldMinX,
-            (-1 * view_Y * config.viewToWorldScale) + config.worldMinY,
+            +1 * view_X * config.viewToWorldScale + config.worldMinX,
+            -1 * view_Y * config.viewToWorldScale + config.worldMinY,
         ];
     }
-
 
     render() {
         const jargonPapers = this.props.getJargonPapers();
@@ -116,9 +105,8 @@ export default class MapCanvas extends Component {
                 zoomControl={config.mapZoomControl}
                 zoomDelta={config.mapZoomDelta}
                 zoomSnap={config.mapZoomSnap}
-                ref={(ref) => this.setMap(ref)}
+                ref={ref => this.setMap(ref)}
             >
-
                 <MapLayerControl
                     getMap={this.getMap}
                     viewToWorld={this.viewToWorld}
@@ -131,23 +119,23 @@ export default class MapCanvas extends Component {
                     worldToView={this.worldToView}
                 />
 
-                {jargonPapers.map((paper, index) =>
+                {jargonPapers.map((paper, index) => (
                     <Circle
                         key={index}
                         center={this.worldToView(paper.x, paper.y)}
                         color={this.calcJargonColor(paper.id)}
                         radius={this.convertRadius(paper.r)}
                     />
-                )}
+                ))}
 
-                {searchPapers.map((paper, index) =>
+                {searchPapers.map((paper, index) => (
                     <Circle
                         key={index}
                         center={this.worldToView(paper.x, paper.y)}
                         color={"white"}
                         radius={this.convertRadius(paper.r)}
                     />
-                )}
+                ))}
             </Map>
         );
     }

--- a/src/scenes/papers/components/map/MapInfoBox.js
+++ b/src/scenes/papers/components/map/MapInfoBox.js
@@ -5,6 +5,7 @@ import { Button, Card, Icon, List } from "semantic-ui-react";
 
 
 export default class MapInfoBox extends Component {
+    /** Component defining the information box upon paper selection */
 
 
     buildArxivLink(arxivID) {

--- a/src/scenes/papers/components/map/MapInfoBox.js
+++ b/src/scenes/papers/components/map/MapInfoBox.js
@@ -3,15 +3,12 @@
 import React, { Component } from "react";
 import { Button, Card, Icon, List } from "semantic-ui-react";
 
-
 export default class MapInfoBox extends Component {
     /** Component defining the information box upon paper selection */
-
 
     buildArxivLink(arxivID) {
         return "https://arxiv.org/pdf/" + arxivID;
     }
-
 
     render() {
         const { getPaperInfo, hidePaperInfo } = this.props;
@@ -25,19 +22,11 @@ export default class MapInfoBox extends Component {
                 </Button>
 
                 <Card.Content>
-                    <Card.Header>
-                        { paperInfo.getTitleForView() }
-                    </Card.Header>
+                    <Card.Header>{paperInfo.getTitleForView()}</Card.Header>
+                    <Card.Description>{paperInfo.getAuthorsForView()}</Card.Description>
                     <Card.Description>
-                        { paperInfo.getAuthorsForView() }
-                    </Card.Description>
-                    <Card.Description>
-                        { paperInfo.getPublisherForView() }
-                        <a
-                            href={arxivLink}
-                            rel="noopener noreferrer"
-                            target="_blank"
-                        >
+                        {paperInfo.getPublisherForView()}
+                        <a href={arxivLink} rel="noopener noreferrer" target="_blank">
                             <Icon name="file pdf" />
                         </a>
                     </Card.Description>
@@ -47,11 +36,11 @@ export default class MapInfoBox extends Component {
                     <List horizontal>
                         <List.Item>
                             <Icon name="linkify" />
-                            { paperInfo.numRefs } references
+                            {paperInfo.numRefs} references
                         </List.Item>
                         <List.Item>
                             <Icon name="file alternate" />
-                            { paperInfo.numCits } citations
+                            {paperInfo.numCits} citations
                         </List.Item>
                     </List>
                 </Card.Content>

--- a/src/scenes/papers/components/map/MapLayerControl.js
+++ b/src/scenes/papers/components/map/MapLayerControl.js
@@ -9,6 +9,7 @@ import { divIcon } from "leaflet";
 
 
 export default class MapLayerControl extends Component {
+    /** Component defining the box with the layer control options */
 
 
     constructor(props) {

--- a/src/scenes/papers/components/map/MapLayerControl.js
+++ b/src/scenes/papers/components/map/MapLayerControl.js
@@ -7,42 +7,41 @@ import MapTilesLayer from "./MapTilesLayer";
 import { FeatureGroup, LayersControl, Marker } from "react-leaflet";
 import { divIcon } from "leaflet";
 
-
 export default class MapLayerControl extends Component {
     /** Component defining the box with the layer control options */
-
 
     constructor(props) {
         super(props);
         this.state = {
-            labels: []
+            labels: [],
         };
 
         // Necessary binding in order to access parent functions
         this.loadLabels = this.loadLabels.bind(this);
     }
 
-
     buildLabel(label) {
         let labelLevels = label.split(",");
-        labelLevels = labelLevels.filter((s) => s !== "");
+        labelLevels = labelLevels.filter(s => s !== "");
         labelLevels = labelLevels.slice(0, 3);
         labelLevels = labelLevels.join("<br>");
 
         return labelLevels;
     }
 
-
     filterWorldLabels(label, northEast, southWest) {
-        return (label.x >= southWest[0] && label.x <= northEast[0])
-            && (label.y >= northEast[1] && label.y <= southWest[1]);
+        return (
+            label.x >= southWest[0] &&
+            label.x <= northEast[0] &&
+            label.y >= northEast[1] &&
+            label.y <= southWest[1]
+        );
     }
-
 
     async loadLabels() {
         let map = this.props.getMap();
 
-        let viewCenter  = map.getCenter();
+        let viewCenter = map.getCenter();
         let worldCenter = this.props.viewToWorld(viewCenter.lng, viewCenter.lat);
         let currentZoom = map.getZoom();
         let roundedZoom = Math.floor(currentZoom);
@@ -50,16 +49,23 @@ export default class MapLayerControl extends Component {
         let labels = await MapLabelsCtl.fetchLabels(roundedZoom, worldCenter);
 
         let viewBounds = map.getBounds();
-        let worldNorthEast = this.props.viewToWorld(viewBounds._northEast.lng, viewBounds._northEast.lat);
-        let worldSouthWest = this.props.viewToWorld(viewBounds._southWest.lng, viewBounds._southWest.lat);
+        let worldNorthEast = this.props.viewToWorld(
+            viewBounds._northEast.lng,
+            viewBounds._northEast.lat
+        );
+        let worldSouthWest = this.props.viewToWorld(
+            viewBounds._southWest.lng,
+            viewBounds._southWest.lat
+        );
 
-        let worldLabels = labels.filter(label => this.filterWorldLabels(label, worldNorthEast, worldSouthWest));
+        let worldLabels = labels.filter(label =>
+            this.filterWorldLabels(label, worldNorthEast, worldSouthWest)
+        );
 
         this.setState({
             labels: worldLabels,
         });
     }
-
 
     render() {
         const { worldToView } = this.props;
@@ -67,9 +73,7 @@ export default class MapLayerControl extends Component {
 
         return (
             <LayersControl position="topleft">
-                <LayersControl.BaseLayer
-                    checked={false}
-                    name="Field">
+                <LayersControl.BaseLayer checked={false} name="Field">
                     <MapTilesLayer
                         url={config.tilesColorHost}
                         attribution={config.tilesAttrib}
@@ -77,9 +81,7 @@ export default class MapLayerControl extends Component {
                         onLoad={this.loadLabels}
                     />
                 </LayersControl.BaseLayer>
-                <LayersControl.BaseLayer
-                    checked={true}
-                    name="Heatmap">
+                <LayersControl.BaseLayer checked={true} name="Heatmap">
                     <MapTilesLayer
                         url={config.tilesGreyHost}
                         attribution={config.tilesAttrib}
@@ -87,21 +89,18 @@ export default class MapLayerControl extends Component {
                         onLoad={this.loadLabels}
                     />
                 </LayersControl.BaseLayer>
-                <LayersControl.Overlay
-                    checked={true}
-                    key={0}
-                    name={"Labels"}>
+                <LayersControl.Overlay checked={true} key={0} name={"Labels"}>
                     <FeatureGroup>
-                        {labels.map((label, index) =>
+                        {labels.map((label, index) => (
                             <Marker
                                 key={index}
                                 position={worldToView(label.x, label.y)}
                                 icon={divIcon({
                                     className: "panel-body-map-label",
-                                    html: this.buildLabel(label["lbl"])
+                                    html: this.buildLabel(label["lbl"]),
                                 })}
                             />
-                        )}
+                        ))}
                     </FeatureGroup>
                 </LayersControl.Overlay>
             </LayersControl>

--- a/src/scenes/papers/components/map/MapLayerControl.js
+++ b/src/scenes/papers/components/map/MapLayerControl.js
@@ -100,8 +100,7 @@ export default class MapLayerControl extends Component {
                                     className: "panel-body-map-label",
                                     html: this.buildLabel(label["lbl"])
                                 })}
-                            >
-                            </Marker>
+                            />
                         )}
                     </FeatureGroup>
                 </LayersControl.Overlay>

--- a/src/scenes/papers/components/map/MapSelectPaper.js
+++ b/src/scenes/papers/components/map/MapSelectPaper.js
@@ -9,6 +9,7 @@ import { Circle } from "react-leaflet";
 
 
 export default class MapSelectPaper extends Component {
+    /** Component defining the paper selection elements */
 
 
     constructor(props) {

--- a/src/scenes/papers/components/map/MapSelectPaper.js
+++ b/src/scenes/papers/components/map/MapSelectPaper.js
@@ -7,10 +7,8 @@ import PaperPositionCtl from "../../controllers/paperscape/PaperPosition";
 import MapInfoBox from "./MapInfoBox";
 import { Circle } from "react-leaflet";
 
-
 export default class MapSelectPaper extends Component {
     /** Component defining the paper selection elements */
-
 
     constructor(props) {
         super(props);
@@ -21,31 +19,28 @@ export default class MapSelectPaper extends Component {
         };
 
         this.map = props.getMap();
-        this.map.on("click", (e) => this.clickToPaperPos(e));
+        this.map.on("click", e => this.clickToPaperPos(e));
 
         // Necessary binding in order to pass these functions to children
         this.getPaperInfo = this.getPaperInfo.bind(this);
         this.hidePaperInfo = this.hidePaperInfo.bind(this);
     }
 
-
     getPaperInfo() {
         return this.state.paperInfo;
     }
 
-
     hidePaperInfo() {
-        this.setState({paperInfoVisible: false});
+        this.setState({ paperInfoVisible: false });
     }
-
 
     _isMapInfoBox(event) {
         let clickedClass = event.originalEvent.target.className;
 
-        return (typeof clickedClass === "string")
-            && (clickedClass.includes("leaflet") === false);
+        return (
+            typeof clickedClass === "string" && clickedClass.includes("leaflet") === false
+        );
     }
-
 
     async clickToPaperPos(event) {
         // Stop click event if it was performed on the information box
@@ -69,11 +64,9 @@ export default class MapSelectPaper extends Component {
         this.updateSelectedPaper(paperPos, paperInfo);
     }
 
-
     convertRadius(radius) {
         return radius * config.worldToViewScale;
     }
-
 
     updateSelectedPaper(paperPos, paperInfo) {
         this.setState({
@@ -83,30 +76,25 @@ export default class MapSelectPaper extends Component {
         });
     }
 
-
     render() {
         const { worldToView } = this.props;
         const { paperPos } = this.state;
 
         return (
             <div>
-                { this.state.paperInfoVisible ?
-                    (
-                        <MapInfoBox
-                            getPaperInfo={this.getPaperInfo}
-                            hidePaperInfo={this.hidePaperInfo}
-                        />
-                    ) : null
-                }
-                { this.state.paperPos !== null ?
-                    (
-                        <Circle
-                            center={worldToView(paperPos.x, paperPos.y)}
-                            color={"yellow"}
-                            radius={this.convertRadius(paperPos.r)}
-                        />
-                    ) : null
-                }
+                {this.state.paperInfoVisible ? (
+                    <MapInfoBox
+                        getPaperInfo={this.getPaperInfo}
+                        hidePaperInfo={this.hidePaperInfo}
+                    />
+                ) : null}
+                {this.state.paperPos !== null ? (
+                    <Circle
+                        center={worldToView(paperPos.x, paperPos.y)}
+                        color={"yellow"}
+                        radius={this.convertRadius(paperPos.r)}
+                    />
+                ) : null}
             </div>
         );
     }

--- a/src/scenes/papers/components/map/MapTilesLayer.js
+++ b/src/scenes/papers/components/map/MapTilesLayer.js
@@ -5,6 +5,7 @@ import { TileLayer } from "leaflet";
 
 
 class MapTilesLayer extends GridLayer {
+    /** Class overriding the default Leaflet GridLayer functionality */
 
 
     getCustomOptions(props) {

--- a/src/scenes/papers/components/map/MapTilesLayer.js
+++ b/src/scenes/papers/components/map/MapTilesLayer.js
@@ -3,10 +3,8 @@
 import { GridLayer, withLeaflet } from "react-leaflet";
 import { TileLayer } from "leaflet";
 
-
 class MapTilesLayer extends GridLayer {
     /** Class overriding the default Leaflet GridLayer functionality */
-
 
     getCustomOptions(props) {
         let options = super.getOptions(props);
@@ -15,16 +13,14 @@ class MapTilesLayer extends GridLayer {
         options.continuousWorld = true;
         options.subdomains = ["1", "2", "3", "4"];
 
-        return options
+        return options;
     }
-
 
     customGetTileUrl(coords) {
         coords.x += 1;
         coords.y += 1;
         return this.defaultGetTileUrl(coords);
     }
-
 
     // Function invoked by the GridLayer
     createLeafletElement(props) {
@@ -38,7 +34,6 @@ class MapTilesLayer extends GridLayer {
         return layer;
     }
 
-
     // Function invoked by the GridLayer
     updateLeafletElement(fromProps, toProps) {
         super.updateLeafletElement(fromProps, toProps);
@@ -48,5 +43,4 @@ class MapTilesLayer extends GridLayer {
     }
 }
 
-
-export default withLeaflet(MapTilesLayer)
+export default withLeaflet(MapTilesLayer);

--- a/src/scenes/papers/controllers/backend/JargonSearch.js
+++ b/src/scenes/papers/controllers/backend/JargonSearch.js
@@ -1,14 +1,11 @@
 /* encoding: utf-8 */
 
-import config from "../../../../config"
-
+import config from "../../../../config";
 
 export default class JargonSearchCtl {
     /** Controller defining Jargon search queries to our own backend */
 
-
     static fetchJargonID(searchJargon) {
-
         // prettier-ignore
         let url = config.dialectMapURL
             + "/jargon/string/"
@@ -20,14 +17,12 @@ export default class JargonSearchCtl {
             .catch(err => console.log(err));
     }
 
-
     static _handleJargonSearchResp(json) {
         let jargonID = null;
 
         try {
             jargonID = json["jargon_id"];
-        }
-        catch(error) {
+        } catch (error) {
             console.log(error);
         }
 

--- a/src/scenes/papers/controllers/backend/JargonSearch.js
+++ b/src/scenes/papers/controllers/backend/JargonSearch.js
@@ -4,6 +4,7 @@ import config from "../../../../config"
 
 
 export default class JargonSearchCtl {
+    /** Controller defining Jargon search queries to our own backend */
 
 
     static fetchJargonID(searchJargon) {

--- a/src/scenes/papers/controllers/backend/JargonSearch.js
+++ b/src/scenes/papers/controllers/backend/JargonSearch.js
@@ -7,6 +7,8 @@ export default class JargonSearchCtl {
 
 
     static fetchJargonID(searchJargon) {
+
+        // prettier-ignore
         let url = config.dialectMapURL
             + "/jargon/string/"
             + encodeURIComponent(searchJargon);

--- a/src/scenes/papers/controllers/backend/MetricSearch.js
+++ b/src/scenes/papers/controllers/backend/MetricSearch.js
@@ -1,15 +1,12 @@
 /* encoding: utf-8 */
 
-import config from "../../../../config"
+import config from "../../../../config";
 import PaperJargonMetric from "../../models/PaperMetric";
-
 
 export default class MetricSearchCtl {
     /** Controller defining metrics search queries to our own backend */
 
-
     static fetchLatestMetrics(jargonID) {
-
         // prettier-ignore
         let url = config.dialectMapURL
             + "/paper/metrics/latest/"
@@ -21,14 +18,12 @@ export default class MetricSearchCtl {
             .catch(err => console.log(err));
     }
 
-
     static _handleMetricSearchResp(json) {
         let metrics = [];
 
         try {
             metrics = json.map(metric => new PaperJargonMetric(metric));
-        }
-        catch(error) {
+        } catch (error) {
             console.log(error);
         }
 

--- a/src/scenes/papers/controllers/backend/MetricSearch.js
+++ b/src/scenes/papers/controllers/backend/MetricSearch.js
@@ -5,6 +5,7 @@ import PaperJargonMetric from "../../models/PaperMetric";
 
 
 export default class MetricSearchCtl {
+    /** Controller defining metrics search queries to our own backend */
 
 
     static fetchLatestMetrics(jargonID) {

--- a/src/scenes/papers/controllers/backend/MetricSearch.js
+++ b/src/scenes/papers/controllers/backend/MetricSearch.js
@@ -8,6 +8,8 @@ export default class MetricSearchCtl {
 
 
     static fetchLatestMetrics(jargonID) {
+
+        // prettier-ignore
         let url = config.dialectMapURL
             + "/paper/metrics/latest/"
             + encodeURIComponent(jargonID);

--- a/src/scenes/papers/controllers/paperscape/MapLabels.js
+++ b/src/scenes/papers/controllers/paperscape/MapLabels.js
@@ -1,21 +1,27 @@
 /* encoding: utf-8 */
 
-import config from "../../../../config"
-
+import config from "../../../../config";
 
 const labelsRespPrefix = "lz_Z_X_Y(";
 const labelsRespSuffix = ")";
 
-
 export default class MapLabelsCtl {
     /** Controller defining the map labels queries to the Paperscape API */
 
-
     static fetchLabels(zoomLevel, centerPos) {
-
-        let labelSpec   = config.worldLabels[zoomLevel];
-        let labelsXTile = this._getLabelTile(centerPos[0], config.worldMinX, config.worldMaxX, labelSpec.nx);
-        let labelsYTile = this._getLabelTile(centerPos[1], config.worldMinY, config.worldMaxY, labelSpec.ny);
+        let labelSpec = config.worldLabels[zoomLevel];
+        let labelsXTile = this._getLabelTile(
+            centerPos[0],
+            config.worldMinX,
+            config.worldMaxX,
+            labelSpec.nx
+        );
+        let labelsYTile = this._getLabelTile(
+            centerPos[1],
+            config.worldMinY,
+            config.worldMaxY,
+            labelSpec.ny
+        );
 
         // prettier-ignore
         let url = config.labelsJsonHost
@@ -30,7 +36,6 @@ export default class MapLabelsCtl {
             .catch(err => console.log(err));
     }
 
-
     static _getLabelTile(coord, coordMin, coordMax, tilesNum) {
         let chunkSize = (coordMax - coordMin) / tilesNum;
         let upperBound = coordMin;
@@ -39,7 +44,7 @@ export default class MapLabelsCtl {
         while (true) {
             upperBound += chunkSize;
             if (coord < upperBound) {
-                break
+                break;
             } else {
                 tileIndex += 1;
             }
@@ -48,16 +53,14 @@ export default class MapLabelsCtl {
         return tileIndex;
     }
 
-
     static _handleLabelsResp(text) {
         let body = this._pruneLabelsResp(text);
         let json = JSON.parse(body);
         return json["lbls"];
     }
 
-
     static _pruneLabelsResp(body) {
-        let startStr  = labelsRespPrefix.length;
+        let startStr = labelsRespPrefix.length;
         let finishStr = body.length - labelsRespSuffix.length;
         return body.substring(startStr, finishStr);
     }

--- a/src/scenes/papers/controllers/paperscape/MapLabels.js
+++ b/src/scenes/papers/controllers/paperscape/MapLabels.js
@@ -7,7 +7,8 @@ const labelsRespPrefix = "lz_Z_X_Y(";
 const labelsRespSuffix = ")";
 
 
-export default class MapLabelsCtl  {
+export default class MapLabelsCtl {
+    /** Controller defining the map labels queries to the Paperscape API */
 
 
     static fetchLabels(zoomLevel, centerPos) {

--- a/src/scenes/papers/controllers/paperscape/MapLabels.js
+++ b/src/scenes/papers/controllers/paperscape/MapLabels.js
@@ -16,6 +16,7 @@ export default class MapLabelsCtl  {
         let labelsXTile = this._getLabelTile(centerPos[0], config.worldMinX, config.worldMaxX, labelSpec.nx);
         let labelsYTile = this._getLabelTile(centerPos[1], config.worldMinY, config.worldMaxY, labelSpec.ny);
 
+        // prettier-ignore
         let url = config.labelsJsonHost
             + "/" + zoomLevel
             + "/" + labelsXTile

--- a/src/scenes/papers/controllers/paperscape/PaperInfo.js
+++ b/src/scenes/papers/controllers/paperscape/PaperInfo.js
@@ -12,6 +12,8 @@ export default class PaperInfoCtl  {
 
 
     static fetchPaperInfo(paperID) {
+
+        // prettier-ignore
         let url = config.papersDataURL
             + "?callback="
             + "&flags[]=1"

--- a/src/scenes/papers/controllers/paperscape/PaperInfo.js
+++ b/src/scenes/papers/controllers/paperscape/PaperInfo.js
@@ -8,7 +8,8 @@ const paperInfoRespPrefix = "(";
 const paperInfoRespSuffix = ")\n";
 
 
-export default class PaperInfoCtl  {
+export default class PaperInfoCtl {
+    /** Controller defining the paper info queries to the Paperscape API */
 
 
     static fetchPaperInfo(paperID) {

--- a/src/scenes/papers/controllers/paperscape/PaperInfo.js
+++ b/src/scenes/papers/controllers/paperscape/PaperInfo.js
@@ -1,19 +1,15 @@
 /* encoding: utf-8 */
 
-import config from "../../../../config"
-import PaperInfo from "../../models/PaperInfo"
-
+import config from "../../../../config";
+import PaperInfo from "../../models/PaperInfo";
 
 const paperInfoRespPrefix = "(";
 const paperInfoRespSuffix = ")\n";
 
-
 export default class PaperInfoCtl {
     /** Controller defining the paper info queries to the Paperscape API */
 
-
     static fetchPaperInfo(paperID) {
-
         // prettier-ignore
         let url = config.papersDataURL
             + "?callback="
@@ -25,7 +21,6 @@ export default class PaperInfoCtl {
             .then(text => this._handlePaperInfoResp(text));
     }
 
-
     static _handlePaperInfoResp(text) {
         let paperInfo = null;
 
@@ -34,14 +29,12 @@ export default class PaperInfoCtl {
             let json = JSON.parse(body);
             let data = json["r"]["papr"][0];
             paperInfo = new PaperInfo(data);
-        }
-        catch(error) {
+        } catch (error) {
             console.log(error);
         }
 
         return paperInfo;
     }
-
 
     static _prunePaperInfoResp(body) {
         let startStr = paperInfoRespPrefix.length;

--- a/src/scenes/papers/controllers/paperscape/PaperPosition.js
+++ b/src/scenes/papers/controllers/paperscape/PaperPosition.js
@@ -1,19 +1,15 @@
 /* encoding: utf-8 */
 
-import config from "../../../../config"
-import PaperPosition from "../../models/PaperPosition"
-
+import config from "../../../../config";
+import PaperPosition from "../../models/PaperPosition";
 
 const paperPosRespPrefix = "(";
 const paperPosRespSuffix = ")\n";
 
-
 export default class PaperPositionCtl {
     /** Controller defining the paper coordinates queries to the Paperscape API */
 
-
     static fetchPaperPos(X_pos, Y_pos) {
-
         // prettier-ignore
         let url = config.papersDataURL
             + "?callback="
@@ -26,7 +22,6 @@ export default class PaperPositionCtl {
             .then(text => this._handlePaperPosResp(text));
     }
 
-
     static _handlePaperPosResp(text) {
         let paperPos = null;
 
@@ -35,14 +30,12 @@ export default class PaperPositionCtl {
             let json = JSON.parse(body);
             let data = json["r"];
             paperPos = new PaperPosition(data);
-        }
-        catch(error) {
+        } catch (error) {
             console.log(error);
         }
 
         return paperPos;
     }
-
 
     static _prunePaperPosResp(body) {
         let startStr = paperPosRespPrefix.length;

--- a/src/scenes/papers/controllers/paperscape/PaperPosition.js
+++ b/src/scenes/papers/controllers/paperscape/PaperPosition.js
@@ -8,7 +8,8 @@ const paperPosRespPrefix = "(";
 const paperPosRespSuffix = ")\n";
 
 
-export default class PaperPositionCtl  {
+export default class PaperPositionCtl {
+    /** Controller defining the paper coordinates queries to the Paperscape API */
 
 
     static fetchPaperPos(X_pos, Y_pos) {

--- a/src/scenes/papers/controllers/paperscape/PaperPosition.js
+++ b/src/scenes/papers/controllers/paperscape/PaperPosition.js
@@ -12,6 +12,8 @@ export default class PaperPositionCtl  {
 
 
     static fetchPaperPos(X_pos, Y_pos) {
+
+        // prettier-ignore
         let url = config.papersDataURL
             + "?callback="
             + "&tbl="

--- a/src/scenes/papers/controllers/paperscape/PaperSearch.js
+++ b/src/scenes/papers/controllers/paperscape/PaperSearch.js
@@ -11,6 +11,8 @@ export default class PaperSearchCtl {
 
 
     static fetchPapersIDs(searchKey, searchValue) {
+
+        // prettier-ignore
         let url = config.papersDataURL
             + this._buildRequestParams(searchKey, searchValue);
 

--- a/src/scenes/papers/controllers/paperscape/PaperSearch.js
+++ b/src/scenes/papers/controllers/paperscape/PaperSearch.js
@@ -8,6 +8,7 @@ const paperSearchRespSuffix = ")\n";
 
 
 export default class PaperSearchCtl {
+    /** Controller defining the paper search queries to the Paperscape API */
 
 
     static fetchPapersIDs(searchKey, searchValue) {

--- a/src/scenes/papers/controllers/paperscape/PaperSearch.js
+++ b/src/scenes/papers/controllers/paperscape/PaperSearch.js
@@ -1,18 +1,14 @@
 /* encoding: utf-8 */
 
-import config from "../../../../config"
-
+import config from "../../../../config";
 
 const paperSearchRespPrefix = "(";
 const paperSearchRespSuffix = ")\n";
 
-
 export default class PaperSearchCtl {
     /** Controller defining the paper search queries to the Paperscape API */
 
-
     static fetchPapersIDs(searchKey, searchValue) {
-
         // prettier-ignore
         let url = config.papersDataURL
             + this._buildRequestParams(searchKey, searchValue);
@@ -21,7 +17,6 @@ export default class PaperSearchCtl {
             .then(resp => resp.text())
             .then(text => this._handlePaperSearchResp(text));
     }
-
 
     static _buildRequestParams(searchKey, searchValue) {
         let params = "?callback=";
@@ -50,7 +45,6 @@ export default class PaperSearchCtl {
         return params;
     }
 
-
     static _handlePaperSearchResp(text) {
         let paperIDs = [];
 
@@ -59,14 +53,12 @@ export default class PaperSearchCtl {
             let json = JSON.parse(body);
             let data = json["r"];
             paperIDs = data.map(paper => paper.id);
-        }
-        catch(error) {
+        } catch (error) {
             console.log(error);
         }
 
         return paperIDs;
     }
-
 
     static _prunePaperSearchResp(body) {
         let startStr = paperSearchRespPrefix.length;

--- a/src/scenes/papers/controllers/paperscape/PaperSearchPosition.js
+++ b/src/scenes/papers/controllers/paperscape/PaperSearchPosition.js
@@ -1,18 +1,16 @@
 /* encoding: utf-8 */
 
-import config from "../../../../config"
-import PaperPosition from "../../models/PaperPosition"
-
+import config from "../../../../config";
+import PaperPosition from "../../models/PaperPosition";
 
 export default class PaperSearchPositionCtl {
     /** Controller defining the paper position search queries to the Paperscape API */
-
 
     static fetchPapersPos(paperIDs) {
         let url = config.papersDataURL;
         let params = {
             method: "POST",
-            headers: {"Content-Type": "application/x-www-form-urlencoded"},
+            headers: { "Content-Type": "application/x-www-form-urlencoded" },
             body: this._buildRequestBody(paperIDs),
         };
 
@@ -20,7 +18,6 @@ export default class PaperSearchPositionCtl {
             .then(resp => resp.json())
             .then(json => this._handlePaperPosResp(json));
     }
-
 
     static _buildRequestBody(paperIDs) {
         let params = "tbl=";
@@ -31,15 +28,13 @@ export default class PaperSearchPositionCtl {
         return params;
     }
 
-
     static _handlePaperPosResp(json) {
         let paperPos = [];
 
         try {
             let data = json["r"];
             paperPos = data.map(paper => new PaperPosition(paper));
-        }
-        catch(error) {
+        } catch (error) {
             console.log(error);
         }
 

--- a/src/scenes/papers/controllers/paperscape/PaperSearchPosition.js
+++ b/src/scenes/papers/controllers/paperscape/PaperSearchPosition.js
@@ -4,7 +4,8 @@ import config from "../../../../config"
 import PaperPosition from "../../models/PaperPosition"
 
 
-export default class PaperSearchPositionCtl  {
+export default class PaperSearchPositionCtl {
+    /** Controller defining the paper position search queries to the Paperscape API */
 
 
     static fetchPapersPos(paperIDs) {

--- a/src/scenes/papers/models/PaperInfo.js
+++ b/src/scenes/papers/models/PaperInfo.js
@@ -6,7 +6,7 @@ const maxCharsPerField = 40;
 
 export default class PaperInfo {
 
-
+    // prettier-ignore
     constructor(data) {
         // Some of these fields may not be in the API response
         this.title   = data["titl"] || "";

--- a/src/scenes/papers/models/PaperInfo.js
+++ b/src/scenes/papers/models/PaperInfo.js
@@ -1,8 +1,6 @@
 /* encoding: utf-8 */
 
-
 const maxCharsPerField = 40;
-
 
 export default class PaperInfo {
     /** Model containing the paper information structure */
@@ -18,29 +16,26 @@ export default class PaperInfo {
         this.numCits = data["nc"];
     }
 
-
     getTitleForView() {
         let shortTitle = this.title.substring(0, maxCharsPerField);
         if (shortTitle.length < this.title.length) {
-            shortTitle += "..."
+            shortTitle += "...";
         }
         return shortTitle;
     }
 
-
     getAuthorsForView() {
         let shortAuthors = this.auth.substring(0, maxCharsPerField);
         if (shortAuthors.length < this.auth.length) {
-            shortAuthors += "..."
+            shortAuthors += "...";
         }
         return shortAuthors;
     }
 
-
     getPublisherForView() {
         let shortPublisher = this.publ.substring(0, maxCharsPerField);
         if (shortPublisher.length < this.publ.length) {
-            shortPublisher += "..."
+            shortPublisher += "...";
         }
         return shortPublisher;
     }

--- a/src/scenes/papers/models/PaperInfo.js
+++ b/src/scenes/papers/models/PaperInfo.js
@@ -5,6 +5,7 @@ const maxCharsPerField = 40;
 
 
 export default class PaperInfo {
+    /** Model containing the paper information structure */
 
     // prettier-ignore
     constructor(data) {

--- a/src/scenes/papers/models/PaperMetric.js
+++ b/src/scenes/papers/models/PaperMetric.js
@@ -1,6 +1,5 @@
 /* encoding: utf-8 */
 
-
 export default class PaperJargonMetric {
     /** Model containing the basic jargon metric structure */
 

--- a/src/scenes/papers/models/PaperMetric.js
+++ b/src/scenes/papers/models/PaperMetric.js
@@ -2,6 +2,7 @@
 
 
 export default class PaperJargonMetric {
+    /** Model containing the basic jargon metric structure */
 
     // prettier-ignore
     constructor(data) {

--- a/src/scenes/papers/models/PaperMetric.js
+++ b/src/scenes/papers/models/PaperMetric.js
@@ -3,7 +3,7 @@
 
 export default class PaperJargonMetric {
 
-
+    // prettier-ignore
     constructor(data) {
         this.id       = data["metric_id"];
         this.jargonID = data["jargon_id"];

--- a/src/scenes/papers/models/PaperPosition.js
+++ b/src/scenes/papers/models/PaperPosition.js
@@ -2,12 +2,13 @@
 
 
 export default class PaperPosition {
+    /** Model containing the basic paper position structure */
 
     // prettier-ignore
-    constructor(apiResponse) {
-        this.id = apiResponse.id;
-        this.x  = apiResponse.x;
-        this.y  = apiResponse.y;
-        this.r  = apiResponse.r;
+    constructor(data) {
+        this.id = data["id"];
+        this.x  = data["x"];
+        this.y  = data["y"];
+        this.r  = data["r"];
     }
 }

--- a/src/scenes/papers/models/PaperPosition.js
+++ b/src/scenes/papers/models/PaperPosition.js
@@ -1,6 +1,5 @@
 /* encoding: utf-8 */
 
-
 export default class PaperPosition {
     /** Model containing the basic paper position structure */
 

--- a/src/scenes/papers/models/PaperPosition.js
+++ b/src/scenes/papers/models/PaperPosition.js
@@ -3,6 +3,7 @@
 
 export default class PaperPosition {
 
+    // prettier-ignore
     constructor(apiResponse) {
         this.id = apiResponse.id;
         this.x  = apiResponse.x;

--- a/src/serviceWorker.js
+++ b/src/serviceWorker.js
@@ -11,125 +11,123 @@
 // opt-in, read http://bit.ly/CRA-PWA
 
 const isLocalhost = Boolean(
-  window.location.hostname === 'localhost' ||
-    // [::1] is the IPv6 localhost address.
-    window.location.hostname === '[::1]' ||
-    // 127.0.0.1/8 is considered localhost for IPv4.
-    window.location.hostname.match(
-      /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
-    )
+    window.location.hostname === "localhost" ||
+        // [::1] is the IPv6 localhost address.
+        window.location.hostname === "[::1]" ||
+        // 127.0.0.1/8 is considered localhost for IPv4.
+        window.location.hostname.match(
+            /^127(?:\.(?:25[0-5]|2[0-4][0-9]|[01]?[0-9][0-9]?)){3}$/
+        )
 );
 
 export function register(config) {
-  if (process.env.NODE_ENV === 'production' && 'serviceWorker' in navigator) {
-    // The URL constructor is available in all browsers that support SW.
-    const publicUrl = new URL(process.env.PUBLIC_URL, window.location.href);
-    if (publicUrl.origin !== window.location.origin) {
-      // Our service worker won't work if PUBLIC_URL is on a different origin
-      // from what our page is served on. This might happen if a CDN is used to
-      // serve assets; see https://github.com/facebook/create-react-app/issues/2374
-      return;
-    }
+    if (process.env.NODE_ENV === "production" && "serviceWorker" in navigator) {
+        // The URL constructor is available in all browsers that support SW.
+        const publicUrl = new URL(process.env.PUBLIC_URL, window.location.href);
+        if (publicUrl.origin !== window.location.origin) {
+            // Our service worker won't work if PUBLIC_URL is on a different origin
+            // from what our page is served on. This might happen if a CDN is used to
+            // serve assets; see https://github.com/facebook/create-react-app/issues/2374
+            return;
+        }
 
-    window.addEventListener('load', () => {
-      const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
+        window.addEventListener("load", () => {
+            const swUrl = `${process.env.PUBLIC_URL}/service-worker.js`;
 
-      if (isLocalhost) {
-        // This is running on localhost. Let's check if a service worker still exists or not.
-        checkValidServiceWorker(swUrl, config);
+            if (isLocalhost) {
+                // This is running on localhost. Let's check if a service worker still exists or not.
+                checkValidServiceWorker(swUrl, config);
 
-        // Add some additional logging to localhost, pointing developers to the
-        // service worker/PWA documentation.
-        navigator.serviceWorker.ready.then(() => {
-          console.log(
-            'This web app is being served cache-first by a service ' +
-              'worker. To learn more, visit http://bit.ly/CRA-PWA'
-          );
+                // Add some additional logging to localhost, pointing developers to the
+                // service worker/PWA documentation.
+                navigator.serviceWorker.ready.then(() => {
+                    console.log(
+                        "This web app is being served cache-first by a service " +
+                            "worker. To learn more, visit http://bit.ly/CRA-PWA"
+                    );
+                });
+            } else {
+                // Is not localhost. Just register service worker
+                registerValidSW(swUrl, config);
+            }
         });
-      } else {
-        // Is not localhost. Just register service worker
-        registerValidSW(swUrl, config);
-      }
-    });
-  }
+    }
 }
 
 function registerValidSW(swUrl, config) {
-  navigator.serviceWorker
-    .register(swUrl)
-    .then(registration => {
-      registration.onupdatefound = () => {
-        const installingWorker = registration.installing;
-        if (installingWorker == null) {
-          return;
-        }
-        installingWorker.onstatechange = () => {
-          if (installingWorker.state === 'installed') {
-            if (navigator.serviceWorker.controller) {
-              // At this point, the updated precached content has been fetched,
-              // but the previous service worker will still serve the older
-              // content until all client tabs are closed.
-              console.log(
-                'New content is available and will be used when all ' +
-                  'tabs for this page are closed. See http://bit.ly/CRA-PWA.'
-              );
+    navigator.serviceWorker
+        .register(swUrl)
+        .then(registration => {
+            registration.onupdatefound = () => {
+                const installingWorker = registration.installing;
+                if (installingWorker == null) {
+                    return;
+                }
+                installingWorker.onstatechange = () => {
+                    if (installingWorker.state === "installed") {
+                        if (navigator.serviceWorker.controller) {
+                            // At this point, the updated precached content has been fetched,
+                            // but the previous service worker will still serve the older
+                            // content until all client tabs are closed.
+                            console.log(
+                                "New content is available and will be used when all " +
+                                    "tabs for this page are closed. See http://bit.ly/CRA-PWA."
+                            );
 
-              // Execute callback
-              if (config && config.onUpdate) {
-                config.onUpdate(registration);
-              }
-            } else {
-              // At this point, everything has been precached.
-              // It's the perfect time to display a
-              // "Content is cached for offline use." message.
-              console.log('Content is cached for offline use.');
+                            // Execute callback
+                            if (config && config.onUpdate) {
+                                config.onUpdate(registration);
+                            }
+                        } else {
+                            // At this point, everything has been precached.
+                            // It's the perfect time to display a
+                            // "Content is cached for offline use." message.
+                            console.log("Content is cached for offline use.");
 
-              // Execute callback
-              if (config && config.onSuccess) {
-                config.onSuccess(registration);
-              }
-            }
-          }
-        };
-      };
-    })
-    .catch(error => {
-      console.error('Error during service worker registration:', error);
-    });
+                            // Execute callback
+                            if (config && config.onSuccess) {
+                                config.onSuccess(registration);
+                            }
+                        }
+                    }
+                };
+            };
+        })
+        .catch(error => {
+            console.error("Error during service worker registration:", error);
+        });
 }
 
 function checkValidServiceWorker(swUrl, config) {
-  // Check if the service worker can be found. If it can't reload the page.
-  fetch(swUrl)
-    .then(response => {
-      // Ensure service worker exists, and that we really are getting a JS file.
-      const contentType = response.headers.get('content-type');
-      if (
-        response.status === 404 ||
-        (contentType != null && contentType.indexOf('javascript') === -1)
-      ) {
-        // No service worker found. Probably a different app. Reload the page.
-        navigator.serviceWorker.ready.then(registration => {
-          registration.unregister().then(() => {
-            window.location.reload();
-          });
+    // Check if the service worker can be found. If it can't reload the page.
+    fetch(swUrl)
+        .then(response => {
+            // Ensure service worker exists, and that we really are getting a JS file.
+            const contentType = response.headers.get("content-type");
+            if (
+                response.status === 404 ||
+                (contentType != null && contentType.indexOf("javascript") === -1)
+            ) {
+                // No service worker found. Probably a different app. Reload the page.
+                navigator.serviceWorker.ready.then(registration => {
+                    registration.unregister().then(() => {
+                        window.location.reload();
+                    });
+                });
+            } else {
+                // Service worker found. Proceed as normal.
+                registerValidSW(swUrl, config);
+            }
+        })
+        .catch(() => {
+            console.log("No internet connection found. App is running in offline mode.");
         });
-      } else {
-        // Service worker found. Proceed as normal.
-        registerValidSW(swUrl, config);
-      }
-    })
-    .catch(() => {
-      console.log(
-        'No internet connection found. App is running in offline mode.'
-      );
-    });
 }
 
 export function unregister() {
-  if ('serviceWorker' in navigator) {
-    navigator.serviceWorker.ready.then(registration => {
-      registration.unregister();
-    });
-  }
+    if ("serviceWorker" in navigator) {
+        navigator.serviceWorker.ready.then(registration => {
+            registration.unregister();
+        });
+    }
 }


### PR DESCRIPTION
This PR addresses issue https://github.com/ds3-nyu-archive/ds-dialect-map-ui/issues/10, by defining [Prettier](https://prettier.io/) as the project default code formatter.

The inclusion of the code formatter involved:
- Defining `prettier` as a dev. dependency within [package.json](https://github.com/ds3-nyu-archive/ds-dialect-map-ui/blob/master/package.json).
- Creating a `.prettierrc.json` to tune default Prettier format options.
- Creating a `.pre-commit-config.yaml` to add Prettier style as a commit requirement.
- Define `check` new rule within the [Makefile](https://github.com/ds3-nyu-archive/ds-dialect-map-ui/blob/22e787b9d055eb3938cb23c149711b58f7b508ee/Makefile).
- Define the project GHA [CI workflow](https://github.com/ds3-nyu-archive/ds-dialect-map-ui/blob/22e787b9d055eb3938cb23c149711b58f7b508ee/.github/workflows/ci.yml), now including both code style check and Docker build.

### Additional changes:
- The [Dockerfile](https://github.com/ds3-nyu-archive/ds-dialect-map-ui/blob/22e787b9d055eb3938cb23c149711b58f7b508ee/Dockerfile) now only installs production dependencies (skipping dev. ones).
- Some specific Javascript code paddings have been marked with `// prettier-ignore` to preserve them (https://github.com/ds3-nyu-archive/ds-dialect-map-ui/commit/1df62c6716f8c17fd5e0ab1fe4ff701f8f80c77c).
- Some render HTML tags have been simplified by removing the unnecessary closing ones (https://github.com/ds3-nyu-archive/ds-dialect-map-ui/commit/6981042b3768907bc34701fa7701f872339046f3).

---

At the end, all JavaScript files within the `src` folder have been automatically formatted by doing:
```sh
npx prettier --write src/**/*.js
```